### PR TITLE
Remove dependency to lodash

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,13 +1,12 @@
-require(['gitbook', 'lodash'], function(gitbook, _) {
+require(['gitbook', 'jquery'], function(gitbook, $) {
     var opts;
-    
+
     gitbook.events.bind('start', function(e, config) {
         opts = config['hide-element'].elements;
     });
 
-
     gitbook.events.bind('page.change', function() {
-        _.map(opts, function(ele){
+        $.map(opts, function(ele) {
             $(ele).hide();
         });
     });


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, GitBook will not provide `lodash` anymore.

The proposed PR has been tested with the new version to use jQuery instead.
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Kind regards,
Johan
